### PR TITLE
refactor: convert footer to server component

### DIFF
--- a/app/(components)/Footer.tsx
+++ b/app/(components)/Footer.tsx
@@ -1,4 +1,8 @@
-"use client"
+import dynamic from 'next/dynamic'
+
+const FooterAnalytics = dynamic(() => import('./FooterAnalytics'), {
+  ssr: false,
+})
 
 export default function Footer() {
   return (
@@ -7,22 +11,23 @@ export default function Footer() {
         <div className="mb-4">
           <a
             href="mailto:luke@analogsauna.com"
+            id="footer-email"
             className="hover:text-ink transition-colors underline"
-            onClick={() => console.log("[v0] Footer email link clicked")}
           >
             luke@analogsauna.com
           </a>
           {" • "}
           <a
             href="tel:+15132820225"
+            id="footer-phone"
             className="hover:text-ink transition-colors underline"
-            onClick={() => console.log("[v0] Footer phone link clicked")}
           >
             (513) 282-0225
           </a>
         </div>
         <div>© {new Date().getFullYear()} Analog Sauna. All rights reserved.</div>
       </div>
+      <FooterAnalytics />
     </footer>
   )
 }

--- a/app/(components)/FooterAnalytics.tsx
+++ b/app/(components)/FooterAnalytics.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect } from 'react'
+
+async function logEvent(event: string) {
+  try {
+    await fetch('/api/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event })
+    })
+  } catch (err) {
+    console.error('Failed to log footer event', err)
+  }
+}
+
+export default function FooterAnalytics() {
+  useEffect(() => {
+    const email = document.getElementById('footer-email')
+    const phone = document.getElementById('footer-phone')
+
+    const handleEmail = () => logEvent('footer_email_click')
+    const handlePhone = () => logEvent('footer_phone_click')
+
+    email?.addEventListener('click', handleEmail)
+    phone?.addEventListener('click', handlePhone)
+
+    return () => {
+      email?.removeEventListener('click', handleEmail)
+      phone?.removeEventListener('click', handlePhone)
+    }
+  }, [])
+
+  return null
+}

--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const { event } = await req.json()
+  console.log(`[analytics] ${event}`)
+  return NextResponse.json({ success: true })
+}


### PR DESCRIPTION
## Summary
- remove client-only code from Footer and load a dynamic analytics hook
- add client hook to log footer link clicks via API route
- implement `/api/log` route for server-side analytics logging

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint? ... ELIFECYCLE Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68bf15e8eb288324935abcc8394b25ed